### PR TITLE
avfilter/avf_showspectrum: fix off-by-one out-of-bounds access (CVE-2024-31585)

### DIFF
--- a/libavfilter/avf_showspectrum.c
+++ b/libavfilter/avf_showspectrum.c
@@ -1779,7 +1779,7 @@ static int showspectrumpic_request_frame(AVFilterLink *outlink)
             int acc_samples = 0;
             int dst_offset = 0;
 
-            while (nb_frame <= s->nb_frames) {
+            while (nb_frame < s->nb_frames) {
                 AVFrame *cur_frame = s->frames[nb_frame];
                 int cur_frame_samples = cur_frame->nb_samples;
                 int nb_samples = 0;


### PR DESCRIPTION
Fixes #43 (CVE-2024-31585).

`showspectrumpic_request_frame()` in `libavfilter/avf_showspectrum.c` loops `while (nb_frame <= s->nb_frames)`, which reads one element past `s->frames[]`.

This backports the upstream one-line fix `ab0fdaedd1e7` ("avfilter/avf_showspectrum: fix off by 1 error"), changing the bound to `<`.

Verified with AddressSanitizer on the enc-5.1 build:
- before: `SEGV ... showspectrumpic_request_frame libavfilter/avf_showspectrum.c` when running `showspectrumpic`
- after: the same invocation completes normally and regular `showspectrum` output is unaffected
